### PR TITLE
fix: remove dll extension at clr.AddReference DotNetLibraryBase

### DIFF
--- a/src/DotNetLibraryBase/base.py
+++ b/src/DotNetLibraryBase/base.py
@@ -75,7 +75,7 @@ class DotNetLibraryBase(DynamicLibrary):
 
             base_path = (Path(__file__).parent / "runtime").absolute()
 
-            clr.AddReference(str(base_path / "RobotFramework.DotNetLibraryBase.dll"))
+            clr.AddReference(str(base_path / "RobotFramework.DotNetLibraryBase"))
 
             from RobotFramework.DotNetLibraryBase import ConsoleRedirectorWriter
 


### PR DESCRIPTION
Using .net9.0, the RobotFramework.DotNetLibraryBase.dll cannot be loaded as assembly. The assembly name should be passed to clr.AddReference function without the "dll"' extension. This also complies with the specification of the clr.AddReference function.